### PR TITLE
Glyphs now converting correctly to unicode string

### DIFF
--- a/templates/_icons.scss
+++ b/templates/_icons.scss
@@ -1,3 +1,3 @@
 $font-icons: (<% _.each(glyphs, function(glyph) { %>
-  <%= glyph.name %>: "<%= glyph.unicode %>",<% }) %>
+  <%= glyph.name %>: "\<%= glyph.unicode[0].codePointAt(0).toString(16).toUpperCase() %>",<% }) %>
 );


### PR DESCRIPTION
I think there was breaking change made in the svg breaking update to the svgicons2svgfont plugin that meant the unicode characters where not being converted correctly. These additional string transformations rectify the issue. 

You may want to make this a variable to keep the template area cleaner - up to you.
